### PR TITLE
fix: use get_user_classroom_ids for admin analytics to show all acces…

### DIFF
--- a/backend/app/routers/analytics.py
+++ b/backend/app/routers/analytics.py
@@ -39,7 +39,7 @@ async def get_admin_analytics_overview(
 ):
     """Get analytics overview for admin - all classrooms and students"""
     try:
-        analytics_data = AnalyticsService.get_admin_analytics_overview(db, admin_user.id)
+        analytics_data = AnalyticsService.get_admin_analytics_overview(db, admin_user)
         return {
             "success": True,
             "data": analytics_data
@@ -60,7 +60,7 @@ async def get_student_analytics_for_admin(
     """Get detailed analytics for a specific student (admin view)"""
     try:
         analytics_data = AnalyticsService.get_student_analytics_for_admin(
-            db, admin_user.id, student_id
+            db, admin_user, student_id
         )
         
         if "error" in analytics_data:
@@ -91,7 +91,7 @@ async def get_classroom_analytics(
     """Get detailed analytics for a specific classroom"""
     try:
         analytics_data = AnalyticsService.get_classroom_analytics(
-            db, admin_user.id, classroom_id
+            db, admin_user, classroom_id
         )
         
         if "error" in analytics_data:

--- a/backend/app/services/analytics_service.py
+++ b/backend/app/services/analytics_service.py
@@ -130,16 +130,33 @@ class AnalyticsService:
         }
     
     @staticmethod
-    def get_admin_analytics_overview(db: Session, admin_user_id: int) -> Dict[str, Any]:
+    def get_admin_analytics_overview(db: Session, admin_user: User) -> Dict[str, Any]:
         """Get analytics overview for admin dashboard"""
         
-        # Get classrooms created by this admin
+        # Import here to avoid circular imports
+        from app.routers.admin import get_user_classroom_ids
+        
+        # Get all classrooms the admin has access to (not just created by them)
+        classroom_ids = get_user_classroom_ids(admin_user)
+        
+        if not classroom_ids:
+            return {
+                "overview": {
+                    "total_students": 0,
+                    "average_success_rate": 0,
+                    "total_submissions": 0,
+                    "active_students_count": 0
+                },
+                "classrooms": [],
+                "language_performance": [],
+                "student_performance": []
+            }
+        
+        # Get classroom objects for context
         admin_classrooms = db.query(Classroom).filter(
-            Classroom.created_by_id == admin_user_id,
+            Classroom.id.in_(classroom_ids),
             Classroom.is_active == True
         ).all()
-        
-        classroom_ids = [c.id for c in admin_classrooms]
         
         # Get all students in admin's classrooms
         student_memberships = db.query(UserClassroom).filter(
@@ -232,16 +249,17 @@ class AnalyticsService:
         }
     
     @staticmethod
-    def get_student_analytics_for_admin(db: Session, admin_user_id: int, student_id: int) -> Dict[str, Any]:
+    def get_student_analytics_for_admin(db: Session, admin_user: User, student_id: int) -> Dict[str, Any]:
         """Get detailed analytics for a specific student (admin view)"""
         
-        # Verify admin has access to this student
-        admin_classrooms = db.query(Classroom).filter(
-            Classroom.created_by_id == admin_user_id,
-            Classroom.is_active == True
-        ).all()
+        # Import here to avoid circular imports
+        from app.routers.admin import get_user_classroom_ids
         
-        classroom_ids = [c.id for c in admin_classrooms]
+        # Get all classrooms the admin has access to
+        classroom_ids = get_user_classroom_ids(admin_user)
+        
+        if not classroom_ids:
+            return {"error": "No classrooms found for admin"}
         
         student_in_classroom = db.query(UserClassroom).filter(
             UserClassroom.user_id == student_id,
@@ -295,13 +313,20 @@ class AnalyticsService:
         return student_analytics
     
     @staticmethod
-    def get_classroom_analytics(db: Session, admin_user_id: int, classroom_id: int) -> Dict[str, Any]:
+    def get_classroom_analytics(db: Session, admin_user: User, classroom_id: int) -> Dict[str, Any]:
         """Get detailed analytics for a specific classroom"""
         
-        # Verify admin owns this classroom
+        # Import here to avoid circular imports
+        from app.routers.admin import get_user_classroom_ids
+        
+        # Verify admin has access to this classroom
+        classroom_ids = get_user_classroom_ids(admin_user)
+        
+        if classroom_id not in classroom_ids:
+            return {"error": "Classroom not found or access denied"}
+            
         classroom = db.query(Classroom).filter(
             Classroom.id == classroom_id,
-            Classroom.created_by_id == admin_user_id,
             Classroom.is_active == True
         ).first()
         


### PR DESCRIPTION
…sible classrooms

🐛 Problem: Admin analytics only showed classrooms created by admin (created_by_id filter)
✅ Solution: Use get_user_classroom_ids() to show ALL classrooms admin has access to

📊 Changes:
- Updated get_admin_analytics_overview() to use admin_user object and get_user_classroom_ids()
- Updated get_student_analytics_for_admin() to use proper classroom access
- Updated get_classroom_analytics() to verify access via get_user_classroom_ids()
- Updated analytics router to pass full admin_user object instead of just ID

🎯 Result: Admin can now see analytics for all classrooms they have access to, not just created ones