### PR TITLE
fix: import get_admin_user from admin router for classroom context

### DIFF
--- a/backend/app/routers/analytics.py
+++ b/backend/app/routers/analytics.py
@@ -7,7 +7,8 @@ from fastapi import APIRouter, Depends, HTTPException, status, Query
 from sqlalchemy.orm import Session
 from app.database.base import get_db
 from app.models.user import User
-from app.routers.auth import get_current_user, get_admin_user
+from app.routers.auth import get_current_user
+from app.routers.admin import get_admin_user
 from app.services.analytics_service import AnalyticsService
 
 router = APIRouter(tags=["analytics"])


### PR DESCRIPTION
🐛 Critical Production Fix:
- Analytics was importing get_admin_user from auth router instead of admin router
- Only admin.get_admin_user sets up classroom_context for get_user_classroom_ids()
- This caused empty classroom data in production analytics

✅ Fixed:
- Import get_admin_user from app.routers.admin instead of app.routers.auth
- Now classroom context will be properly set for analytics endpoints