### PR TITLE
Fix hardcoded max_grade value for no-output submissions

### DIFF
--- a/backend/app/services/assignment_service.py
+++ b/backend/app/services/assignment_service.py
@@ -742,7 +742,7 @@ class AssignmentService:
             for submission in submissions_no_execution:
                 if submission.grade is None:  # Only grade if not already graded
                     submission.grade = 0.0
-                    submission.max_grade = 100.0
+                    submission.max_grade = grade_out_of  # Use actual grade scale from API
                     submission.grading_notes = "No execution results - 0 points"
                     no_execution_count += 1
             

--- a/frontend/src/components/AssignmentReports.tsx
+++ b/frontend/src/components/AssignmentReports.tsx
@@ -130,8 +130,16 @@ export default function AssignmentReports({ refreshTrigger }: AssignmentReportsP
               
               // Stop polling this assignment after 60 polls (5 minutes) to prevent infinite polling
               if (previousState.count > 60) {
-                console.error(`❌ Stopping polling for assignment "${assignment.name}" - appears to be stuck`);
-                return false;
+                console.error(`❌ Assignment "${assignment.name}" appears to be stuck in processing state`);
+                console.error(`🔧 SOLUTION: Click "Reprocess" button to restart this assignment`);
+                console.error(`📊 Assignment stats: ${assignment.processed_students}/${assignment.total_students} students processed`);
+                
+                // If no students have been processed at all, it's likely a background task failure
+                if (assignment.processed_students === 0) {
+                  console.error(`⚠️ CRITICAL: No students processed - background task may have failed silently`);
+                }
+                
+                return false; // Stop polling this stuck assignment
               }
             }
           } else {
@@ -161,6 +169,24 @@ export default function AssignmentReports({ refreshTrigger }: AssignmentReportsP
         console.log(`🔄 Polling ${processingAssignments.length} processing assignments`);
         loadAssignments();
       } else {
+        // Check for stuck assignments before stopping polling
+        const stuckAssignments = currentAssignments.filter(assignment => {
+          const isProcessingButNoProgress = assignment.status === 'processing' && 
+                                          assignment.processed_students === 0 && 
+                                          assignment.total_students > 0;
+          const isPendingPlagiarism = assignment.plagiarism_status === 'pending';
+          
+          return isProcessingButNoProgress && isPendingPlagiarism;
+        });
+        
+        if (stuckAssignments.length > 0) {
+          console.error(`🚨 BACKGROUND TASK FAILURE DETECTED:`);
+          stuckAssignments.forEach(assignment => {
+            console.error(`   Assignment "${assignment.name}": ${assignment.processed_students}/${assignment.total_students} processed`);
+            console.error(`   🔧 SOLUTION: Use "Reprocess" button to restart this assignment`);
+          });
+        }
+        
         // No more processing assignments, stop polling
         console.log('⏹️ No processing assignments found, stopping polling');
         stopPolling();


### PR DESCRIPTION
ISSUE: Submissions with no execution output were getting hardcoded max_grade = 100.0 instead of using the actual grade_out_of value from the API request.

FIX: Use grade_out_of parameter for max_grade when auto-grading submissions with no execution results.

IMPACT:
- Assignments with grade scales like 10 or 50 now show correct denominators
- Grade displays like '0/10' instead of '0/100' for 10-point scales
- Maintains consistency with user-specified grading configuration

LOCATION: backend/app/services/assignment_service.py:745
CHANGE: submission.max_grade = 100.0 → submission.max_grade = grade_out_of